### PR TITLE
feat: Add language switch

### DIFF
--- a/.vitepress/theme/nav.js
+++ b/.vitepress/theme/nav.js
@@ -4,39 +4,64 @@ const { defaultVersion, versions } = generateVersions()
 // 定义每个类别及其子项的映射
 const categoryMappings = {
     "zh": {
-        "item": "文档版本",
-        "defaultVersion": defaultVersion,
-        "link": "/start/whatis.md"
+        "docs_version": {
+            "item": "文档版本",
+            "defaultVersion": defaultVersion,
+            "link": "/start/whatis.md"
+        },
+        "language": {
+            "text": "语言",
+            "items": [
+                { "text": '中文', "link": '/guide/start/whatis.md' },
+                { "text": '英文', "link": '/en/guide/start/whatis.md' }
+            ]
+        }
     },
     "en": {
-        "item": "Doc Version",
-        "defaultVersion": defaultVersion,
-        "link": "/start/whatis.md"
+        "docs_version": {
+            "item": "Doc Version",
+            "defaultVersion": defaultVersion,
+            "link": "/start/whatis.md"
+        },
+        "language": {
+            "text": "Language",
+            "items": [
+                { "text": 'Chinese', "link": '/guide/start/whatis.md' },
+                { "text": 'English', "link": '/en/guide/start/whatis.md' }
+            ]
+        }
     }
 }
 
 // 函数来生成特定语言和版本的导航栏
 function generateNav(language) {
-    lst = [];
-    const items = [];
+    lst = []
+    const docs_items = [];
+
     // 检测 md 文件是否存在。
     versions.forEach(version => {
         const versionPrefix = version ? `${version}/` : '';
         const pathPrefix = language === 'zh'
             ? `/${versionPrefix}guide`
             : `/${versionPrefix}${language}/guide`;
-        const defaultVersion = version ? `${version}` : categoryMappings[language]['defaultVersion'];
-        items.push({
+        const defaultVersion = version ? `${version}` : categoryMappings[language]['docs_version']['defaultVersion'];
+        docs_items.push({
             text: defaultVersion,
-            link: `${pathPrefix}${categoryMappings[language]['link']}`
+            link: `${pathPrefix}${categoryMappings[language]['docs_version']['link']}`
         });
     });
 
     lst.push({
-        text: categoryMappings[language]['item'],
+        text: categoryMappings[language]['docs_version']['item'],
         ariaLabel: "Version Menu",
-        items: items
+        items: docs_items
     });
+
+    lst.push({
+        text: categoryMappings[language]['language']['text'],
+        items: categoryMappings[language]['language']['items']
+    })
+
     return lst;
 }
 


### PR DESCRIPTION
添加语言切换的下拉菜单，不过由于是静态网站，路由是固定的，语言切换默认链的是对应语言最新版本。
例如：
点击中文，链接 /guide/start/whatis.md，点击英文，链接 /en/guide/start/whatis.md，如果在对应某个版本如1.5.x版本点击切换，英文并不会链接的 1.5.x/en/guide/start/whatis.md，而是链接的 /en/guide/start/whatis.md