### PR TITLE
fix: github pages build failure

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: ["master"]
+  pull_request:
   workflow_dispatch:
 permissions:
   contents: read
@@ -17,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           cache: "yarn"
       - name: Install Depend
         run: yarn install


### PR DESCRIPTION
修复因nodejs版本过低导致github pages构建失败